### PR TITLE
Add missing parentheses in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Calibex.Mixfile do
     [app: :calibex,
      version: "0.1.0",
      elixir: "~> 1.3",
-     package: package,
-     description: description,
+     package: package(),
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps()]


### PR DESCRIPTION
Elixir 1.15 introduced a change in [compiler warnings and errors](https://hexdocs.pm/elixir/1.15/changelog.html#compiler-warnings-and-errors).

One could call the `Code.compiler_options(on_undefined_variable: :warn)` as described in [potential incompatibilities](https://hexdocs.pm/elixir/1.15/changelog.html#potential-incompatibilities-1) section, but of course it's better to just fix the root cause :)

The issue itself is as follows:
```
error: undefined variable "package"
  /app/deps/calibex/mix.exs:8: Calibex.Mixfile.project/0

error: undefined variable "description"
  /app/deps/calibex/mix.exs:9: Calibex.Mixfile.project/0

warning: function description/0 is unused
  /app/deps/calibex/mix.exs:30: Calibex.Mixfile (module)

warning: function package/0 is unused
  /app/deps/calibex/mix.exs:24: Calibex.Mixfile (module)

Error while loading project :calibex at /app/deps/calibex
** (CompileError) deps/calibex/mix.exs: cannot compile module Calibex.Mixfile (errors have been logged)
```